### PR TITLE
Command-line title should be in English

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "iiifx-production/yii2-autocomplete-helper",
-    "type": "extension",
+    "type": "yii2-extension",
     "description": "Yii2 Autocomplete Helper",
     "keywords": [
         "yii2",

--- a/source/Controller.php
+++ b/source/Controller.php
@@ -55,17 +55,11 @@ class Controller extends \yii\console\Controller
         return [];
     }
 
-    public function echoInfo ()
-    {
-        echo 'Yii2 IDE Autocomplete Helper' . PHP_EOL . 'Vitaliy IIIFX Khomenko, 2017' . PHP_EOL;
-    }
-
     /**
      * Generate IDE auto-completion code.
      */
     public function actionIndex ()
     {
-        $this->echoInfo();
         try {
             $component = $this->getComponent();
             $configList = $this->getConfig( $component );

--- a/source/Controller.php
+++ b/source/Controller.php
@@ -15,7 +15,7 @@ use yii\base\InvalidConfigException;
 use yii\helpers\FileHelper;
 
 /**
- * Class Controller
+ * Automatically generate IDE auto-completion file.
  *
  * @package iiifx\Yii2\Autocomplete
  */

--- a/source/Controller.php
+++ b/source/Controller.php
@@ -61,7 +61,7 @@ class Controller extends \yii\console\Controller
     }
 
     /**
-     * Точка входа
+     * Generate IDE auto-completion code.
      */
     public function actionIndex ()
     {


### PR DESCRIPTION
Hi, I think this component should be more international, so modify the title into English.
The output of the `Info` causes confusion throughout the command line (multiple output), so I removed it.

